### PR TITLE
Use api utils for api calls

### DIFF
--- a/hooks/useAuth.js
+++ b/hooks/useAuth.js
@@ -2,14 +2,14 @@ import axios from 'axios'
 import cookie from '../utils/cookie';
 import { useDataProviderContext } from '../contexts/DataContext';
 import Router from 'next/router'
+import api from '../utils/api'
 
 const useAuth = () => {
     const { setUser } = useDataProviderContext()
-    const baseUrl = process.env.NEXT_PUBLIC_SERVER_HOST
     const login = async (event) => {
         const data = new FormData(event.currentTarget);
         try {
-            const result = await axios.post(`${baseUrl}/auth/login`, {
+            const result = await api().post("auth/login", null, {
                 email: data.get("email"),
                 password: data.get("password")
             })
@@ -24,7 +24,7 @@ const useAuth = () => {
             if (e.response) {
                 if (e.response.status == '401' || e.response.status === '500') {
                     alert("Sorry, Login failed")
-                } else if(e.response.status === 400){
+                } else if (e.response.status === 400) {
                     alert("Login failed, Bad request")
                 } else {
                     alert("Sorry, Can't process your request")
@@ -38,7 +38,7 @@ const useAuth = () => {
     const register = async (event) => {
         const data = new FormData(event.currentTarget);
         try {
-            const result = await axios.post(`${baseUrl}/auth/signup`, {
+            const result = await api().post(`auth/signup`, null, {
                 email: data.get("email"),
                 password: data.get("password")
             })
@@ -53,7 +53,7 @@ const useAuth = () => {
             if (e.response) {
                 if (e.response.status === 401 || e.response.status === 500) {
                     alert("Sorry, Registration failed")
-                } else if(e.response.status === 400){
+                } else if (e.response.status === 400) {
                     alert("Registration failed, Bad request")
                 } else {
                     alert("Sorry, Cann't process your request")

--- a/hooks/useAuth.js
+++ b/hooks/useAuth.js
@@ -1,4 +1,3 @@
-import axios from 'axios'
 import cookie from '../utils/cookie';
 import { useDataProviderContext } from '../contexts/DataContext';
 import Router from 'next/router'

--- a/hooks/useKeyword.js
+++ b/hooks/useKeyword.js
@@ -1,40 +1,31 @@
 import React from 'react'
-import axios from 'axios'
 import cookie from '../utils/cookie'
+import api from '../utils/api'
 
 const useKeyword = () => {
     const [selectedFile, setSelectedFile] = React.useState()
     const [keywords, setKeywords] = React.useState([])
     const [searchKey, setSearchKey] = React.useState("")
-    const baseUrl = process.env.NEXT_PUBLIC_SERVER_HOST
 
 
     const handleSearch = async (e) => {
         e.preventDefault()
         try {
-            const result = await axios(`${baseUrl}/user/keywords?search=${searchKey}`, {
-                method: 'GET',
-                headers: {
-                    'Authorization': `Bearer ${cookie.getAccessTokenCookie()}`
-                }
-            })
+            const result = await api().get(`user/keywords?search=${searchKey}`, cookie.getAccessTokenCookie())
             setKeywords(result.data)
         } catch (e) {
             console.log(e)
+            alert("Failed to search keywords")
         }
     }
 
     const loadKeywords = async () => {
         try {
-            const result = await axios(`${baseUrl}/user/keywords`, {
-                method: 'GET',
-                headers: {
-                    'Authorization': `Bearer ${cookie.getAccessTokenCookie()}`
-                }
-            })
+            const result = await api().get(`user/keywords`, cookie.getAccessTokenCookie())
             setKeywords(result.data)
         } catch (e) {
             console.log(e)
+            alert("Failed to fetch keywords")
         }
     }
 
@@ -47,13 +38,7 @@ const useKeyword = () => {
         const formData = new FormData();
         formData.append('file', selectedFile);
         try {
-            const result = await axios(`${baseUrl}/user/keywords`, {
-                method: 'POST',
-                data: formData,
-                headers: {
-                    'Authorization': `Bearer ${cookie.getAccessTokenCookie()}`
-                }
-            })
+            const result = await api().post(`user/keywords`, cookie.getAccessTokenCookie(), formData)
             if (result.status === 201) {
                 const tempArray = keywords.concat(result.data)
                 setKeywords(tempArray)

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,7 +1,7 @@
 import '../styles/globals.css'
 import Cookie from '../utils/cookie'
 import { DataProvider } from '../contexts/DataContext';
-import { api } from '../utils/api';
+import api from '../utils/api';
 
 function MyApp({ Component, pageProps, }) {
   return <DataProvider me={pageProps.user}><Component {...pageProps} /></DataProvider>
@@ -12,19 +12,22 @@ MyApp.getInitialProps = async ({ Component, ctx }) => {
   let token = Cookie.getAccessTokenCookieAtRequest(ctx)
   let me = null
   if (token) {
-    me = await api("user", token)
-    if (!me) {
+    try {
+      const response = await api().get("user", token)
+      if (response && response.data) {
+        me = response.data
+      }
+    } catch (e) {
       Cookie.removeAccessTokenCookieAtRequest(ctx)
       ctx.res.writeHead(302, { Location: "/login" });
       ctx.res.end();
     }
   } else {
-    if (ctx.pathname == "/register") {
-
-    }
-    else if (ctx.pathname !== "/login" && ctx.res !== undefined) {
-      ctx.res.writeHead(302, { Location: "/login" });
-      ctx.res.end();
+    if (ctx.pathname !== "/login" && ctx.res !== undefined) {
+      if (ctx.pathname != "/register") {
+        ctx.res.writeHead(302, { Location: "/login" });
+        ctx.res.end();
+      }
     }
   }
   return { pageProps: { user: me } };

--- a/utils/api.js
+++ b/utils/api.js
@@ -1,17 +1,29 @@
 import axios from 'axios'
 
-export const api = async (url, token = null) => {
+const api = () => {
     const baseUrl = process.env.NEXT_PUBLIC_SERVER_HOST
-    try {
+    const get = async (url, token) => {
         const response = await axios(`${baseUrl}/${url}`, {
             method: 'GET',
             headers: {
                 ...(token && { 'Authorization': `Bearer ${token}` })
             }
         })
-        return response.data
-    } catch (e) {
-        console.log(e)
-        return null
+        return response
     }
+
+    const post = async (url, token, data) => {
+        const response = await axios(`${baseUrl}/${url}`, {
+            method: 'POST',
+            data: data,
+            headers: {
+                ...(token && { 'Authorization': `Bearer ${token}` })
+            }
+        })
+        return response
+    }
+
+    return { get, post }
 }
+
+export default api


### PR DESCRIPTION
closes #2 

These changes will make api calls more consistent by using api utill method to send `get` and `post` request across application.
`useAuth` and `useDashboard` hooks now use these methods to implement api calls. 
